### PR TITLE
Correct minimal Python version on several places

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -69,11 +69,11 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v2.4.0
-      - name: 🏗 Set up Python 3.8
+      - name: 🏗 Set up Python 3.9
         id: python
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: 🏗 Read .nvmrc
         if: ${{ matrix.id == 'prettier' }}
         id: nvm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v2.4.0
-      - name: 🏗 Set up Python 3.8
+      - name: 🏗 Set up Python 3.9
         id: python
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: 🏗 Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/typing.yaml
+++ b/.github/workflows/typing.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10"]
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v2.4.0
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8, 3.9]
+        python: ["3.10"]
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v2.4.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -964,8 +964,8 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.8"
-content-hash = "f2aaab6337e1498bfc395ef808c4ab466c3c962377c9eb20c7dcdfbf83fcb858"
+python-versions = "^3.9"
+content-hash = "83d808016af8fab158093c4fc76e298fef6b9d61443cf9776223bd79724d6813"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ aiohttp = ">=3.0.0"
 awesomeversion = ">=21.10.1"
 backoff = ">=1.9.0"
 pydantic = "^1.9.0"
-python = "^3.8"
+python = "^3.9"
 yarl = ">=1.6.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
# Proposed Changes

Correction for the Python versions uses in a couple of places. This library requires Python 3.9+
