### PR TITLE
Relax Wi-Fi rssi & encryption parameters

### DIFF
--- a/src/demetriek/models.py
+++ b/src/demetriek/models.py
@@ -65,12 +65,12 @@ class Wifi(BaseModel):
     active: bool
     mac: str
     available: bool
-    encryption: str
+    encryption: Optional[str] = None
     ssid: str
     ip: IPv4Address
     mode: WifiMode
     netmask: str
-    rssi: int
+    rssi: Optional[int] = None
 
 
 class Device(BaseModel):

--- a/tests/fixtures/device2.json
+++ b/tests/fixtures/device2.json
@@ -1,0 +1,70 @@
+{
+  "audio": {
+    "volume": 100,
+    "volume_limit": {
+      "max": 100,
+      "min": 0
+    },
+    "volume_range": {
+      "max": 100,
+      "min": 0
+    }
+  },
+  "bluetooth": {
+    "active": false,
+    "address": "AA:BB:CC:DD:EE:FF",
+    "available": true,
+    "discoverable": true,
+    "low_energy": {
+      "active": true,
+      "advertising": true,
+      "connectable": true
+    },
+    "name": "LM1234",
+    "pairable": true
+  },
+  "display": {
+    "brightness": 100,
+    "brightness_limit": {
+      "max": 100,
+      "min": 2
+    },
+    "brightness_mode": "auto",
+    "brightness_range": {
+      "max": 100,
+      "min": 0
+    },
+    "height": 8,
+    "screensaver": {
+      "enabled": false,
+      "modes": {
+        "time_based": {
+          "enabled": true,
+          "local_start_time": "01:00:39",
+          "start_time": "00:00:39"
+        },
+        "when_dark": {
+          "enabled": false
+        }
+      },
+      "widget": "08b8eac21074f8f7e5a29f2855ba8060"
+    },
+    "type": "mixed",
+    "width": 37
+  },
+  "id": "12345",
+  "mode": "auto",
+  "model": "LM 37X8",
+  "name": "Frenck's LaMetric",
+  "os_version": "2.2.2",
+  "serial_number": "SA110405124500W00BS9",
+  "wifi": {
+    "active": true,
+    "address": "AA:BB:CC:DD:EE:FF",
+    "available": true,
+    "essid": "Frenck",
+    "ip": "192.168.1.11",
+    "mode": "dhcp",
+    "netmask": "255.255.255.0"
+  }
+}

--- a/tests/fixtures/wifi2.json
+++ b/tests/fixtures/wifi2.json
@@ -1,0 +1,10 @@
+{
+  "active": true,
+  "available": true,
+  "ipv4": "192.168.1.2",
+  "mac": "AA:BB:CC:DD:EE:FF",
+  "mode": "dhcp",
+  "netmask": "255.255.255.0",
+  "signal_strength": null,
+  "ssid": "AllYourBaseAreBelongToUs"
+}

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -62,3 +62,55 @@ async def test_get_device(aresponses: ResponsesMockServer) -> None:
     assert device.wifi.mode is WifiMode.DHCP
     assert device.wifi.netmask == "255.255.255.0"
     assert device.wifi.rssi == 21
+
+
+@pytest.mark.asyncio
+async def test_get_device2(aresponses: ResponsesMockServer) -> None:
+    """Test getting device information."""
+    aresponses.add(
+        "127.0.0.2:4343",
+        "/api/v2/device",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("device2.json"),
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        demetriek = LaMetricDevice(host="127.0.0.2", api_key="abc", session=session)
+        device = await demetriek.device()
+
+    assert device
+    assert device.device_id == "12345"
+    assert device.name == "Frenck's LaMetric"
+    assert device.os_version == "2.2.2"
+    assert device.mode is DeviceMode.AUTO
+    assert device.model == "LM 37X8"
+    assert device.audio.volume == 100
+    assert device.audio.volume_range
+    assert device.audio.volume_range.range_min == 0
+    assert device.audio.volume_range.range_max == 100
+    assert device.audio.volume_limit
+    assert device.audio.volume_limit.range_min == 0
+    assert device.audio.volume_limit.range_max == 100
+    assert device.bluetooth.available is True
+    assert device.bluetooth.name == "LM1234"
+    assert device.bluetooth.active is False
+    assert device.bluetooth.discoverable is True
+    assert device.bluetooth.pairable is True
+    assert device.bluetooth.address == "AA:BB:CC:DD:EE:FF"
+    assert device.display.brightness == 100
+    assert device.display.brightness_mode is BrightnessMode.AUTO
+    assert device.display.width == 37
+    assert device.display.height == 8
+    assert device.display.display_type is DisplayType.MIXED
+    assert device.wifi.active is True
+    assert device.wifi.available is True
+    assert device.wifi.mac == "AA:BB:CC:DD:EE:FF"
+    assert device.wifi.encryption is None
+    assert device.wifi.ssid == "Frenck"
+    assert device.wifi.ip == IPv4Address("192.168.1.11")
+    assert device.wifi.mode is WifiMode.DHCP
+    assert device.wifi.netmask == "255.255.255.0"
+    assert device.wifi.rssi is None

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -13,7 +13,7 @@ from . import load_fixture
 
 
 @pytest.mark.asyncio
-async def test_get_audio(aresponses: ResponsesMockServer) -> None:
+async def test_get_wifi(aresponses: ResponsesMockServer) -> None:
     """Test getting audio information."""
     aresponses.add(
         "127.0.0.2:4343",
@@ -39,3 +39,32 @@ async def test_get_audio(aresponses: ResponsesMockServer) -> None:
     assert wifi.netmask == "255.255.255.0"
     assert wifi.ssid == "AllYourBaseAreBelongToUs"
     assert wifi.rssi == 42
+
+
+@pytest.mark.asyncio
+async def test_get_wifi2(aresponses: ResponsesMockServer) -> None:
+    """Test getting audio information."""
+    aresponses.add(
+        "127.0.0.2:4343",
+        "/api/v2/device/wifi",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text=load_fixture("wifi2.json"),
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        demetriek = LaMetricDevice(host="127.0.0.2", api_key="abc", session=session)
+        wifi = await demetriek.wifi()
+
+    assert wifi
+    assert wifi.active is True
+    assert wifi.mac == "AA:BB:CC:DD:EE:FF"
+    assert wifi.available is True
+    assert wifi.encryption is None
+    assert wifi.ip == IPv4Address("192.168.1.2")
+    assert wifi.mode == WifiMode.DHCP
+    assert wifi.netmask == "255.255.255.0"
+    assert wifi.ssid == "AllYourBaseAreBelongToUs"
+    assert wifi.rssi is None


### PR DESCRIPTION
# Proposed Changes

Relaxes the `rssi` and `encryption` reported values. Multiple reports came in, where those two have been missing (or `None`).

They are not critical, so relaxing their validation in this PR.

fixes #223
Ref:
- https://github.com/home-assistant/core/issues/78605
- https://github.com/home-assistant/core/issues/77980
- https://github.com/home-assistant/core/issues/78079
