### PR TITLE
Fix device mode to allow schedule

### DIFF
--- a/src/demetriek/const.py
+++ b/src/demetriek/const.py
@@ -16,6 +16,7 @@ class DeviceMode(str, Enum):
     AUTO = "auto"
     KIOSK = "kiosk"
     MANUAL = "manual"
+    SCHEDULE = "schedule"
 
 
 class DeviceState(str, Enum):

--- a/tests/fixtures/device2.json
+++ b/tests/fixtures/device2.json
@@ -53,7 +53,7 @@
     "width": 37
   },
   "id": "12345",
-  "mode": "auto",
+  "mode": "schedule",
   "model": "LM 37X8",
   "name": "Frenck's LaMetric",
   "os_version": "2.2.2",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -85,7 +85,7 @@ async def test_get_device2(aresponses: ResponsesMockServer) -> None:
     assert device.device_id == "12345"
     assert device.name == "Frenck's LaMetric"
     assert device.os_version == "2.2.2"
-    assert device.mode is DeviceMode.AUTO
+    assert device.mode is DeviceMode.SCHEDULE
     assert device.model == "LM 37X8"
     assert device.audio.volume == 100
     assert device.audio.volume_range


### PR DESCRIPTION
# Proposed Changes

Adds the schedule device mode. Although not documented, it does actually exists.
Once activating the schedule in the app, the device will communicate `schedule` as its mode.

## Related Issues

https://github.com/home-assistant/core/issues/78180