### PR TITLE
Add support for catching authentication failures

### DIFF
--- a/src/demetriek/__init__.py
+++ b/src/demetriek/__init__.py
@@ -15,6 +15,7 @@ from .const import (
 )
 from .device import LaMetricDevice
 from .exceptions import (
+    LaMetricAuthenticationError,
     LaMetricConnectionError,
     LaMetricConnectionTimeoutError,
     LaMetricError,
@@ -52,6 +53,7 @@ __all__ = [
     "Goal",
     "GoalData",
     "LaMetricCloud",
+    "LaMetricAuthenticationError",
     "LaMetricConnectionError",
     "LaMetricConnectionTimeoutError",
     "LaMetricDevice",

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -16,6 +16,7 @@ from yarl import URL
 
 from .const import BrightnessMode
 from .exceptions import (
+    LaMetricAuthenticationError,
     LaMetricConnectionError,
     LaMetricConnectionTimeoutError,
     LaMetricError,
@@ -90,6 +91,14 @@ class LaMetricDevice:
         except asyncio.TimeoutError as exception:
             raise LaMetricConnectionTimeoutError(
                 f"Timeout occurred while connecting to the LaMetric device at {self.host}"
+            ) from exception
+        except aiohttp.ClientResponseError as exception:
+            if exception.status in [401, 403]:
+                raise LaMetricAuthenticationError(
+                    f"Authentication to the LaMetric device at {self.host} failed"
+                ) from exception
+            raise LaMetricError(
+                f"Error occurred while connecting to the LaMetric device at {self.host}"
             ) from exception
         except (aiohttp.ClientError, socket.gaierror) as exception:
             raise LaMetricConnectionError(

--- a/src/demetriek/exceptions.py
+++ b/src/demetriek/exceptions.py
@@ -9,5 +9,9 @@ class LaMetricConnectionError(LaMetricError):
     """LaMetric connection exception."""
 
 
+class LaMetricAuthenticationError(LaMetricError):
+    """LaMetric authentication exception."""
+
+
 class LaMetricConnectionTimeoutError(LaMetricConnectionError):
     """LaMetric connection Timeout exception."""


### PR DESCRIPTION
# Proposed Changes

Adds support for catching authentication failures. This will help with introducing re-authentication in the Home Assistant integration for LaMetric.
