### PR TITLE
Add screensaver enabled status to the Display model

### DIFF
--- a/src/demetriek/models.py
+++ b/src/demetriek/models.py
@@ -49,6 +49,12 @@ class Bluetooth(BaseModel):
     address: str
 
 
+class DisplayScreensaver(BaseModel):
+    """Object holding the screensaver data of an LaMetric device."""
+
+    enabled: bool
+
+
 class Display(BaseModel):
     """Object holding the display state of an LaMetric device."""
 
@@ -57,6 +63,7 @@ class Display(BaseModel):
     width: int
     height: int
     display_type: DisplayType = Field(None, alias="type")
+    screensaver: DisplayScreensaver
 
 
 class Wifi(BaseModel):

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -53,6 +53,7 @@ async def test_get_device(aresponses: ResponsesMockServer) -> None:
     assert device.display.width == 37
     assert device.display.height == 8
     assert device.display.display_type is DisplayType.MIXED
+    assert device.display.screensaver.enabled is False
     assert device.wifi.active is True
     assert device.wifi.available is True
     assert device.wifi.mac == "AA:BB:CC:DD:EE:FF"


### PR DESCRIPTION
# Proposed Changes

This PR adds the ability to retrieve the screensaver status from the device via a new model (`DisplayScreensaver`) attached to the `Display` model. The motivation is https://github.com/home-assistant/core/issues/81637 – users get `unknown_error` requests when they attempt to send notifications to a device with the screensaver active. Since [devices in screensaver mode can only receive critical notifications](https://github.com/home-assistant/core/issues/81637#issuecomment-1307443318), this PR will enable a more accurate log/message to the user when sending notifications in this setting.

Note that I did not implement the entirety of the `screensaver` payload; I want to keep this PR contained to the surface area it will actually touch.

## Related Issues

N/A

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
