### PR TITLE
Alter exception handling to utilize response data

### DIFF
--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -16,6 +16,7 @@ from yarl import URL
 
 from .const import BrightnessMode
 from .exceptions import (
+    LaMetricAuthenticationError,
     LaMetricConnectionError,
     LaMetricConnectionTimeoutError,
     LaMetricError,
@@ -91,6 +92,10 @@ class LaMetricDevice:
             try:
                 response.raise_for_status()
             except aiohttp.ClientResponseError as exception:
+                if exception.status in (401, 403):
+                    raise LaMetricAuthenticationError(
+                        f"Authentication to the LaMetric device at {self.host} failed"
+                    ) from exception
                 raise_on_data_error(self.host, response_data, exception)
 
         except asyncio.TimeoutError as exception:

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -97,7 +97,7 @@ class LaMetricDevice:
             raise LaMetricConnectionTimeoutError(
                 f"Timeout occurred while connecting to the LaMetric device at {self.host}"
             ) from exception
-        except socket.gaierror as exception:
+        except (aiohttp.ClientError, socket.gaierror) as exception:
             raise LaMetricConnectionError(
                 f"Error occurred while communicating with the LaMetric device at {self.host}"
             ) from exception

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -16,7 +16,6 @@ from yarl import URL
 
 from .const import BrightnessMode
 from .exceptions import (
-    LaMetricAuthenticationError,
     LaMetricConnectionError,
     LaMetricConnectionTimeoutError,
     LaMetricError,
@@ -60,7 +59,6 @@ class LaMetricDevice:
             LaMetric device.
 
         Raises:
-            LaMetricAuthenticationError: If the API key is invalid.
             LaMetricConnectionError: An error occurred while communication with
                 the LaMetric device.
             LaMetricConnectionTimeoutError: A timeout occurred while communicating
@@ -88,12 +86,12 @@ class LaMetricDevice:
             if "application/json" not in content_type:
                 raise LaMetricError(response.status, {"message": await response.text()})
 
-            data: dict[str, Any] = await response.json()
+            response_data: dict[str, Any] = await response.json()
 
             try:
                 response.raise_for_status()
             except aiohttp.ClientResponseError as exception:
-                raise_on_data_error(data, exception)
+                raise_on_data_error(response_data, exception)
 
         except asyncio.TimeoutError as exception:
             raise LaMetricConnectionTimeoutError(
@@ -104,19 +102,7 @@ class LaMetricDevice:
                 f"Error occurred while communicating with the LaMetric device at {self.host}"
             ) from exception
 
-        return data
-        # except aiohttp.ClientResponseError as exception:
-        #     if exception.status in [401, 403]:
-        #         raise LaMetricAuthenticationError(
-        #             f"Authentication to the LaMetric device at {self.host} failed"
-        #         ) from exception
-        #     raise LaMetricError(
-        #         f"Error occurred while connecting to the LaMetric device at {self.host}"
-        #     ) from exception
-        # except (aiohttp.ClientError, socket.gaierror) as exception:
-        #     raise LaMetricConnectionError(
-        #         f"Error occurred while communicating with the LaMetric device at {self.host}"
-        #     ) from exception
+        return response_data
 
     async def device(self) -> Device:
         """Get LaMetric device information.

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -91,7 +91,7 @@ class LaMetricDevice:
             try:
                 response.raise_for_status()
             except aiohttp.ClientResponseError as exception:
-                raise_on_data_error(response_data, exception)
+                raise_on_data_error(self.host, response_data, exception)
 
         except asyncio.TimeoutError as exception:
             raise LaMetricConnectionTimeoutError(

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -60,6 +60,7 @@ class LaMetricDevice:
             LaMetric device.
 
         Raises:
+            LaMetricAuthenticationError: If the API key is invalid.
             LaMetricConnectionError: An error occurred while communication with
                 the LaMetric device.
             LaMetricConnectionTimeoutError: A timeout occurred while communicating

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -20,7 +20,6 @@ from .exceptions import (
     LaMetricConnectionError,
     LaMetricConnectionTimeoutError,
     LaMetricError,
-    raise_on_data_error,
 )
 from .models import Audio, Bluetooth, Device, Display, Notification, Wifi
 
@@ -97,7 +96,13 @@ class LaMetricDevice:
                     raise LaMetricAuthenticationError(
                         f"Authentication to the LaMetric device at {self.host} failed"
                     ) from exception
-                raise_on_data_error(self.host, response_data, exception)
+
+                raise LaMetricError(
+                    (
+                        f"Error occurred while communicating with the LaMetric device "
+                        f"at {self.host}: {response_data['errors'][0]['message']}"
+                    )
+                ) from exception
 
         except asyncio.TimeoutError as exception:
             raise LaMetricConnectionTimeoutError(

--- a/src/demetriek/exceptions.py
+++ b/src/demetriek/exceptions.py
@@ -39,13 +39,6 @@ def raise_on_data_error(
     if (errors := data.get("errors")) is None:
         return
 
-    # Although this exception doesn't make use of the response data, we include it here
-    # for completeness and specificity:
-    if raising_exception.status in (401, 403):
-        raise LaMetricAuthenticationError(
-            f"Authentication to the LaMetric device at {host} failed"
-        ) from raising_exception
-
     raise LaMetricError(
         (
             f"Error occurred while communicating with the LaMetric device at {host}: "

--- a/src/demetriek/exceptions.py
+++ b/src/demetriek/exceptions.py
@@ -1,4 +1,9 @@
 """Exceptions for LaMetric."""
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
 
 
 class LaMetricError(Exception):
@@ -15,3 +20,29 @@ class LaMetricAuthenticationError(LaMetricError):
 
 class LaMetricConnectionTimeoutError(LaMetricConnectionError):
     """LaMetric connection Timeout exception."""
+
+
+EXCEPTION_MESSAGE_MAP = {
+    "Authorization is required": LaMetricAuthenticationError,
+}
+
+
+def raise_on_data_error(
+    data: dict[str, Any], raising_error: aiohttp.ClientResponseError
+) -> None:
+    """Raise an exception (if appropriate) based on response data.
+
+    Args:
+        data: An API response payload.
+        raising_error: The original aiohttp.ClientResponseError.
+
+    Raises:
+        exc: An appropriate LaMetricError (or subclass).
+    """
+    if (errors := data.get("errors")) is None:
+        return
+
+    error = errors[0]
+    exc = EXCEPTION_MESSAGE_MAP.get(error["message"], LaMetricError)
+    exc.__cause__ = raising_error
+    raise exc(error)


### PR DESCRIPTION
# Proposed Changes

Following up on https://github.com/frenck/python-demetriek/pull/275#issuecomment-1309103412. The current HTTP exception handling swallows important response data, preventing implementors from more nuance in their applications. This PR alters things to include the response data (when appropriate) in the raised exception.

As an example, this is the current response when attempting to send a non-critical notification to a device with screensaver mode active:

```
Traceback (most recent call last):
  File "/Users/bachya/Git/python-demetriek/src/demetriek/device.py", line 77, in _request
    response = await self.session.request(
  File "/Users/bachya/.virtualenvs/python-demetriek/lib/python3.10/site-packages/aiohttp/client.py", line 643, in _request
    resp.raise_for_status()
  File "/Users/bachya/.virtualenvs/python-demetriek/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 1005, in raise_for_status
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 400, message='Bad Request', url=URL('https://192.168.1.100:4343/api/v2/device/notifications')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/bachya/Git/python-demetriek/examples/example.py", line 58, in <module>
    asyncio.run(main())
  File "/Users/bachya/.pyenv/versions/3.10.5/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/bachya/.pyenv/versions/3.10.5/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/Users/bachya/Git/python-demetriek/examples/example.py", line 54, in main
    await lametric.notify(notification=notification)
  File "/Users/bachya/Git/python-demetriek/src/demetriek/device.py", line 243, in notify
    response = await self._request(
  File "/Users/bachya/.virtualenvs/python-demetriek/lib/python3.10/site-packages/backoff/_async.py", line 151, in retry
    ret = await target(*args, **kwargs)
  File "/Users/bachya/Git/python-demetriek/src/demetriek/device.py", line 101, in _request
    raise LaMetricError(
demetriek.exceptions.LaMetricError: Error occurred while connecting to the LaMetric device at 192.168.1.100
```

With this PR, the exception now includes more useful information:

```
Traceback (most recent call last):
  File "/Users/bachya/Git/python-demetriek/src/demetriek/device.py", line 92, in _request
    response.raise_for_status()
  File "/Users/bachya/.virtualenvs/python-demetriek/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 1005, in raise_for_status
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 400, message='Bad Request', url=URL('https://192.168.1.100:4343/api/v2/device/notifications')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/bachya/Git/python-demetriek/examples/example.py", line 58, in <module>
    asyncio.run(main())
  File "/Users/bachya/.pyenv/versions/3.10.5/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/bachya/.pyenv/versions/3.10.5/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/Users/bachya/Git/python-demetriek/examples/example.py", line 54, in main
    await lametric.notify(notification=notification)
  File "/Users/bachya/Git/python-demetriek/src/demetriek/device.py", line 241, in notify
    response = await self._request(
  File "/Users/bachya/.virtualenvs/python-demetriek/lib/python3.10/site-packages/backoff/_async.py", line 151, in retry
    ret = await target(*args, **kwargs)
  File "/Users/bachya/Git/python-demetriek/src/demetriek/device.py", line 94, in _request
    raise_on_data_error(self.host, response_data, exception)
  File "/Users/bachya/Git/python-demetriek/src/demetriek/exceptions.py", line 47, in raise_on_data_error
    raise LaMetricError(
demetriek.exceptions.LaMetricError: Error occurred while communicating with the LaMetric device at 192.168.1.100: Only notifications with priority 'critical' are allowed in current mode
```

Once the overall idea is approved, I'll add tests and make sure CI passes.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
