### PR TITLE
Add ability to enable/disable screensaver

### DIFF
--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -159,7 +159,7 @@ class LaMetricDevice:
             A Display object, with latest or updated information about
             the display of the LaMetric device.
         """
-        data: dict[str, int | BrightnessMode] = {}
+        data: dict[str, int | BrightnessMode | dict[str, bool]] = {}
 
         if brightness is not None:
             data["brightness"] = brightness

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -144,6 +144,7 @@ class LaMetricDevice:
         *,
         brightness: int | None = None,
         brightness_mode: BrightnessMode | None = None,
+        screensaver_enabled: bool | None = None,
     ) -> Display:
         """Get or set LaMetric device display information.
 
@@ -151,6 +152,7 @@ class LaMetricDevice:
         ----
             brightness: Brightness level to set.
             brightness_mode: Brightness mode to set.
+            screensaver_enabled: Whether the screensaver should be enabled.
 
         Returns:
         -------
@@ -164,6 +166,9 @@ class LaMetricDevice:
 
         if brightness_mode is not None:
             data["brightness_mode"] = brightness_mode
+
+        if screensaver_enabled is not None:
+            data["screensaver"] = {"enabled": screensaver_enabled}
 
         if data:
             response = await self._request(

--- a/src/demetriek/models.py
+++ b/src/demetriek/models.py
@@ -49,6 +49,12 @@ class Bluetooth(BaseModel):
     address: str
 
 
+class DisplayScreensaver(BaseModel):
+    """Object holding the screensaver data of an LaMetric device."""
+
+    enabled: bool
+
+
 class Display(BaseModel):
     """Object holding the display state of an LaMetric device."""
 
@@ -57,6 +63,7 @@ class Display(BaseModel):
     width: int
     height: int
     display_type: DisplayType | None = Field(default=None, alias="type")
+    screensaver: DisplayScreensaver
 
 
 class Wifi(BaseModel):

--- a/tests/fixtures/display_set.json
+++ b/tests/fixtures/display_set.json
@@ -16,9 +16,7 @@
         "enabled": false,
         "modes": {
           "time_based": {
-            "enabled": true,
-            "local_start_time": "01:00:39",
-            "start_time": "00:00:39"
+            "enabled": false
           },
           "when_dark": {
             "enabled": false

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -51,6 +51,7 @@ async def test_get_device(aresponses: ResponsesMockServer) -> None:
     assert device.display.width == 37
     assert device.display.height == 8
     assert device.display.display_type is DisplayType.MIXED
+    assert device.display.screensaver.enabled is False
     assert device.wifi.active is True
     assert device.wifi.available is True
     assert device.wifi.mac == "AA:BB:CC:DD:EE:FF"

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -42,6 +42,9 @@ async def test_set_display(aresponses: ResponsesMockServer) -> None:
         assert data == {
             "brightness": 99,
             "brightness_mode": "manual",
+            "screensaver": {
+                "enabled": False,
+            },
         }
         return aresponses.Response(
             status=200,
@@ -56,6 +59,7 @@ async def test_set_display(aresponses: ResponsesMockServer) -> None:
         display = await demetriek.display(
             brightness=99,
             brightness_mode=BrightnessMode.MANUAL,
+            screensaver_enabled=False,
         )
 
     assert display
@@ -64,3 +68,4 @@ async def test_set_display(aresponses: ResponsesMockServer) -> None:
     assert display.width == 37
     assert display.height == 8
     assert display.display_type is DisplayType.MIXED
+    assert display.screensaver.enabled is False


### PR DESCRIPTION
# Proposed Changes

_(fresh attempt on https://github.com/frenck/python-demetriek/pull/275)._

This PR adds the ability to enable/disable the screensaver. It does not include anything having to do with the screensaver mode or mode params (e.g., setting a certain mode for a certain time)—the request and response payloads for these attributes differ in non-trivial ways and it's not immediately clear to me how to incorporate them.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
