### PR TITLE
Set *.py indent to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_size = 2
 
+[*.py]
+indent_size = 4
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Minor change to `.editorconfig`

All python files are currently using 4 spaces for indentation, so I assume it's a mistake that `.editorconfig` was set to 2 spaces
