### PR TITLE
Extend API to support app control

### DIFF
--- a/examples/countdown.py
+++ b/examples/countdown.py
@@ -1,0 +1,59 @@
+import asyncio
+
+from demetriek import LaMetricDevice, DeviceMode, Application
+
+
+async def main() -> None:
+    """Show how an app can be controlled from the API"""
+    # Find the countdown app
+    # Change mode to MANUAL
+    # Set the duration to 5 seconds
+    # Start the countdown
+    # 8 seconds after starting the countdown, reset it again
+    # Switch back to what-ever mode was selected before the script ran
+
+    async with LaMetricDevice(
+        "192.168.1.11",
+        api_key="DEVICE_API_KEY",
+    ) as lametric:
+        # Find the countdown app
+        apps = await lametric.apps()
+        countdown: Application | None = apps.get("com.lametric.countdown")
+        if not countdown:
+            raise Exception("No countdown app")
+
+        # we'll restore to the previous mode after we're done
+        prev_mode = await lametric.mode()
+        await lametric.mode(mode=DeviceMode.MANUAL)
+
+        # find the widget
+        if len(countdown.widgets) == 0:
+            raise Exception("No countdown widget")
+        widget_key = list(countdown.widgets.keys())[0]
+
+        # we already know the parameters, but we just print them to show how
+        # a client could get information about parameters
+        print(countdown.actions["countdown.configure"])
+
+        # configure countdown
+        await lametric.do_action(package=countdown.package,
+                                 action="countdown.configure",
+                                 widget=widget_key,
+                                 activate=True,
+                                 params={
+                                     "duration": 5,
+                                 })
+
+        # start countdown
+        await lametric.do_action(package=countdown.package, action="countdown.start", widget=widget_key, activate=True)
+        await asyncio.sleep(8)
+
+        # the clock should be beeping now, reset it
+        await lametric.do_action(package=countdown.package, action="countdown.reset", widget=widget_key, activate=True)
+
+        # go back to the previous mode
+        await lametric.mode(mode=prev_mode)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/toggle_dark.py
+++ b/examples/toggle_dark.py
@@ -1,0 +1,43 @@
+import asyncio
+from demetriek import LaMetricDevice, DeviceMode, Application
+
+
+async def main() -> None:
+    """Show how to manually select which app is visible."""
+    # Imagine this script is triggered by a smart home,
+    # and when it's bedtime the script will switch
+    # the LaMetric clock to manual mode and activate the "Dark" app
+    # (na app which just blanks the screen)
+    async with LaMetricDevice(
+        "192.168.1.11",
+        api_key="DEVICE_API_KEY",
+    ) as lametric:
+        # Find the "Dark" app: https://apps.lametric.com/apps/dark/542
+        apps = await lametric.apps()
+        dark_app: Application | None = None
+        for app in apps.values():
+            if app.title == "Dark":
+                dark_app = app
+
+        if not dark_app:
+            raise Exception("Dark app not found")
+
+        # activate dark
+        package = dark_app.package
+        if len(dark_app.widgets) == 0:
+            raise Exception("Dark app has no widgets")
+        widget = list(dark_app.widgets.keys())[0]  # dark only have one widget
+
+        # toggle between AUTO and MANUAL
+        mode = await lametric.mode()
+        if mode == DeviceMode.AUTO:
+            # Switch to manual
+            await lametric.mode(mode=DeviceMode.MANUAL)
+            await lametric.activate_widget(package=package, widget=widget)
+        else:
+            # back to auto
+            await lametric.mode(mode=DeviceMode.AUTO)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/demetriek/__init__.py
+++ b/src/demetriek/__init__.py
@@ -21,6 +21,7 @@ from .exceptions import (
     LaMetricError,
 )
 from .models import (
+    Application,
     Audio,
     Bluetooth,
     Chart,
@@ -31,15 +32,18 @@ from .models import (
     GoalData,
     Model,
     Notification,
+    Parameter,
     Range,
     Simple,
     Sound,
     User,
+    Widget,
     Wifi,
 )
 
 __all__ = [
     "AlarmSound",
+    "Application",
     "Audio",
     "Bluetooth",
     "BrightnessMode",
@@ -52,8 +56,8 @@ __all__ = [
     "DisplayType",
     "Goal",
     "GoalData",
-    "LaMetricCloud",
     "LaMetricAuthenticationError",
+    "LaMetricCloud",
     "LaMetricConnectionError",
     "LaMetricConnectionTimeoutError",
     "LaMetricDevice",
@@ -65,10 +69,12 @@ __all__ = [
     "NotificationSound",
     "NotificationSoundCategory",
     "NotificationType",
+    "Parameter",
     "Range",
     "Simple",
     "Sound",
     "User",
+    "Widget",
     "Wifi",
     "WifiMode",
 ]

--- a/src/demetriek/const.py
+++ b/src/demetriek/const.py
@@ -129,3 +129,8 @@ class WifiMode(str, Enum):
 
     DHCP = "dhcp"
     STATIC = "static"
+
+class ParameterType(str, Enum):
+    BOOL = "bool"
+    INT = "int"
+    STRING = "string"

--- a/src/demetriek/models.py
+++ b/src/demetriek/models.py
@@ -19,6 +19,7 @@ from .const import (
     NotificationSound,
     NotificationSoundCategory,
     NotificationType,
+    ParameterType,
     WifiMode,
 )
 
@@ -177,6 +178,32 @@ class Model(BaseModel):
     frames: list[Chart | Goal | Simple]
     sound: Sound | None = None
     cycles: int = 1
+
+
+class Widget(BaseModel):
+    index: int
+    package: str
+    visible: bool
+
+
+class Parameter(BaseModel):
+    data_type: ParameterType
+    name: str
+    required: bool
+    format: str | None = None
+
+
+class Application(BaseModel):
+    package: str
+    vendor: str
+    version: str
+    version_code: str
+
+    actions: dict[str, dict[str, Parameter]] | None = None
+    widgets: dict[str, Widget]
+
+    # not mentioned in the docs
+    title: str
 
 
 class Notification(BaseModel):


### PR DESCRIPTION
# Proposed Changes

LaMetric recently (No idea when since there's no timestamp on the docs) updated their documentation on [app control](https://lametric-documentation.readthedocs.io/en/latest/reference-docs/device-apps.html) to include API calls to configure and activate specific widgets.

This change adds the ability to:
* Change mode: I.e. switch between AUTO / MANUAL / SCHEDULE / KIOSK
* Fetch information about all installed apps
* Change active widgets
* Call actions. E.g. start the countdown timer

I've added two new samples demonstrating these new API calls.

## Home Assistant integration

I'm interested in using these new calls in my home assistant setup. The dream is to automatically switch my LaMetric clock to a "Dark" app when I go to bed so the display is completely off, and then turn it back to it's normal "auto" mode at sunrise.

I'll be happy to extend the current home-assistant component but I could use a few hints as to how these calls should be exposed. (is it just a service, or do we somehow expose the list of apps as individual entities that can be "activated", or something completely different)