### PR TITLE
Fix typo on the code of conduct file.

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, religion, or sexual identity
 and orientation.
 


### PR DESCRIPTION
# Proposed Changes

Splitting up https://github.com/frenck/python-demetriek/pull/740

On the file `.github/CODE_OF_CONDUCT.md`, the codespell pre-commit was failing for the word `socio-economic`, so I changed it to `socioeconomic`. Seems like the [word is not hyphenated](https://www.collinsdictionary.com/de/worterbuch/englisch/socioeconomic)
