### PR TITLE
Add include hidden files option to artifact upload.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,8 @@ jobs:
         with:
           name: coverage-${{ matrix.python }}
           path: .coverage
+          if-no-files-found: error
+          include-hidden-files: true
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Proposed Changes

Splitting up https://github.com/frenck/python-demetriek/pull/740

I had to adapt the upload of artifacts because of https://github.com/actions/upload-artifact/issues/602, since the .coverage file would not be uploaded anymore without the `include-hidden-files` option.

I also added the `if-no-files-found: error`, because this file is required for the next step either way.