### PR TITLE
Remove async_timeouts and replace it with asyncio.timeouts.

### DIFF
--- a/src/demetriek/cloud.py
+++ b/src/demetriek/cloud.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import asyncio.timeouts
 import socket
 from dataclasses import dataclass
 from typing import Any, Self
@@ -75,7 +74,7 @@ class LaMetricCloud:
         }
 
         try:
-            async with asyncio.timeouts.timeout(self.request_timeout):
+            async with asyncio.timeout(self.request_timeout):
                 response = await self.session.request(
                     hdrs.METH_GET,
                     url,

--- a/src/demetriek/cloud.py
+++ b/src/demetriek/cloud.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio.timeouts
 import socket
 from dataclasses import dataclass
 from typing import Any, Self
 
 import aiohttp
-import async_timeout
 import backoff
 from aiohttp import hdrs
 from pydantic import parse_obj_as
@@ -75,7 +75,7 @@ class LaMetricCloud:
         }
 
         try:
-            async with async_timeout.timeout(self.request_timeout):
+            async with asyncio.timeouts.timeout(self.request_timeout):
                 response = await self.session.request(
                     hdrs.METH_GET,
                     url,

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio.timeouts
 import socket
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self, cast
 
 import aiohttp
-import async_timeout
 import backoff
 from aiohttp import hdrs
 from aiohttp.helpers import BasicAuth
@@ -81,7 +81,7 @@ class LaMetricDevice:
             self._close_session = True
 
         try:
-            async with async_timeout.timeout(self.request_timeout):
+            async with asyncio.timeouts.timeout(self.request_timeout):
                 response = await self.session.request(
                     method,
                     url,

--- a/src/demetriek/device.py
+++ b/src/demetriek/device.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-import asyncio.timeouts
 import socket
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self, cast
@@ -81,7 +80,7 @@ class LaMetricDevice:
             self._close_session = True
 
         try:
-            async with asyncio.timeouts.timeout(self.request_timeout):
+            async with asyncio.timeout(self.request_timeout):
                 response = await self.session.request(
                     method,
                     url,


### PR DESCRIPTION
# Proposed Changes

Splitting of https://github.com/frenck/python-demetriek/pull/740

`async_timeout.timeout` has been replaced by `asyncio.timeouts.timeout`. See that the [original library is not deprecated](https://pypi.org/project/async-timeout/), and they recommend you to use asyncio instead. Since this library only supports Python 3.11 and above, the dependency is completely dropped (wasn't on the `pyproject.toml` either way).