### PR TITLE
Remove deprecation warnings when running ruff

### DIFF
--- a/examples/ruff.toml
+++ b/examples/ruff.toml
@@ -1,6 +1,7 @@
 # This extend our general Ruff rules specifically for the examples
 extend = "../pyproject.toml"
 
+[lint]
 extend-ignore = [
   "T201", # Allow the use of print() in examples
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ max-attributes = 20
 addopts = "--cov"
 asyncio_mode = "auto"
 
-[tool.ruff]
+[tool.ruff.lint]
 ignore = [
   "ANN101", # Self... explanatory
   "ANN102", # cls... just as annoying as ANN101
@@ -153,17 +153,17 @@ ignore = [
 ]
 select = ["ALL"]
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["demetriek"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 25
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "src/demetriek/models.py" = ["TCH002", "TCH003"]
 
 [build-system]

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,6 +1,7 @@
 # This extend our general Ruff rules specifically for tests
 extend = "../pyproject.toml"
 
+[lint]
 extend-select = [
   "PT", # Use @pytest.fixture without parentheses
 ]


### PR DESCRIPTION
# Proposed Changes

Splitting of #740 

As described in [Ruff settings docs](https://docs.astral.sh/ruff/settings/), all the options related to linting should be inside `[tool.ruff.lint]`.