### PR TITLE
Fix serialization of notifications with no sound

### DIFF
--- a/src/demetriek/models.py
+++ b/src/demetriek/models.py
@@ -194,7 +194,10 @@ class Model(DataClassORJSONMixin):
 
     cycles: int = 1
     frames: list[Chart | Goal | Simple]
-    sound: SoundURL | Sound | None
+    sound: SoundURL | Sound | None = None
+
+    class Config(BaseConfig):
+        omit_none = True
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
# Proposed Changes

In v0.4.0, the Model's `sound` argument was optional and worked as expected. Now in >v1.0.0, the `sound` is required and has type `Sound | SoundURL | None`.

**The error:** with `sound=None` my LaMetric returns a 400 (`{ "errors" : [ { "message" : "Marshalling failed: Variant containing QVariant::Invalid passed in arguments" } ] }`) because the payload is invalid. Fixes are either to serialize sound=None as `"sound": "none"`, or simply skip serializing this property when it's none (what I chose).

This PR makes the `Model.sound` field optional (like before) and skips its serialization when it's None.